### PR TITLE
Feature/397483 pbi from another project

### DIFF
--- a/src/ServiceNowCLI.Core/Arguments/CommandLineArguments.cs
+++ b/src/ServiceNowCLI.Core/Arguments/CommandLineArguments.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -49,8 +50,8 @@ namespace ServiceNowCLI.Core.Arguments
                 return new List<int>();
             }
 
-            return AddWorkitems.Split(',', System.StringSplitOptions.RemoveEmptyEntries)
-                .Select(x => int.Parse(x.Trim())).ToList();
+            return AddWorkitems.Split(',', System.StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(int.Parse).ToList();
         }
     }
 

--- a/src/ServiceNowCLI.Core/Arguments/CommandLineArguments.cs
+++ b/src/ServiceNowCLI.Core/Arguments/CommandLineArguments.cs
@@ -1,4 +1,6 @@
 ﻿using CommandLine;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ServiceNowCLI.Core.Arguments
 {
@@ -36,6 +38,20 @@ namespace ServiceNowCLI.Core.Arguments
         public string TransformTemplateFile { get; set; }
 
         public bool IncludeAllLinkedWorkItems => WorkItemLinking == "All";
+
+        [Option('a', "addWorkitems", Required = false, Default = "", HelpText = "Comma-separated list of work item IDs to add to the CR (e.g., 123,456,789)")]
+        public string AddWorkitems { get; set; }
+
+        public List<int> GetAddWorkitemIds()
+        {
+            if (string.IsNullOrWhiteSpace(AddWorkitems))
+            {
+                return new List<int>();
+            }
+
+            return AddWorkitems.Split(',', System.StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => int.Parse(x.Trim())).ToList();
+        }
     }
 
     public class SetActivityOptions

--- a/src/ServiceNowCLI.Core/AzureDevOps/BuildLogic.cs
+++ b/src/ServiceNowCLI.Core/AzureDevOps/BuildLogic.cs
@@ -125,10 +125,6 @@ namespace ServiceNowCLI.Core.AzureDevOps
 
             var workItemIds = workItemsRef.Select(wi => int.Parse(wi.Id)).ToList();
 
-            if (workItemIds.Count == 0)
-                throw new ArgumentException(
-                    "No Work Items could be found for release, please ensure that your build has linked work items!");
-
             var workItemsForConsole = string.Join(", ",workItemIds.Select(x => x));
             Console.WriteLine($"{workItemIds.Count} linked work items found for BuildNumber={build.BuildNumber}, BuildId={build.Id}: {workItemsForConsole}");
 

--- a/src/ServiceNowCLI.Core/AzureDevOps/BuildLogic.cs
+++ b/src/ServiceNowCLI.Core/AzureDevOps/BuildLogic.cs
@@ -117,21 +117,22 @@ namespace ServiceNowCLI.Core.AzureDevOps
             return build;
         }
 
-        public List<ResourceRef> GetBuildLinkedWorkItems(Build build)
+        public List<int> GetBuildLinkedWorkItemIds(Build build)
         {
             Console.WriteLine($"Getting linked work items from BuildNumber={build.BuildNumber}, BuildId={build.Id}");
 
-            var workItems = _buildsClient.GetBuildWorkItemsRefsAsync(build.Project.Id, build.Id).GetAwaiter().GetResult();
+            var workItemsRef = _buildsClient.GetBuildWorkItemsRefsAsync(build.Project.Id, build.Id).GetAwaiter().GetResult();
 
-            if (workItems.Count == 0)
+            var workItemIds = workItemsRef.Select(wi => int.Parse(wi.Id)).ToList();
+
+            if (workItemIds.Count == 0)
                 throw new ArgumentException(
                     "No Work Items could be found for release, please ensure that your build has linked work items!");
 
-            var workItemsForConsole = string.Join(", ",workItems.Select(x => x.Id));
+            var workItemsForConsole = string.Join(", ",workItemIds.Select(x => x));
+            Console.WriteLine($"{workItemIds.Count} linked work items found for BuildNumber={build.BuildNumber}, BuildId={build.Id}: {workItemsForConsole}");
 
-            Console.WriteLine($"{workItems.Count} linked work items found for BuildNumber={build.BuildNumber}, BuildId={build.Id}: {workItemsForConsole}");
-
-            return workItems;
+            return workItemIds;
         }
 
         public List<string> GetBranchesForTag(string tagName, string repoId)

--- a/src/ServiceNowCLI.Core/AzureDevOps/BuildLogic.cs
+++ b/src/ServiceNowCLI.Core/AzureDevOps/BuildLogic.cs
@@ -119,14 +119,14 @@ namespace ServiceNowCLI.Core.AzureDevOps
 
         public List<int> GetBuildLinkedWorkItemIds(Build build)
         {
-            Console.WriteLine($"Getting linked work items from BuildNumber={build.BuildNumber}, BuildId={build.Id}");
+            Console.WriteLine($"Getting referenced work items from BuildNumber={build.BuildNumber}, BuildId={build.Id}");
 
             var workItemsRef = _buildsClient.GetBuildWorkItemsRefsAsync(build.Project.Id, build.Id).GetAwaiter().GetResult();
 
             var workItemIds = workItemsRef.Select(wi => int.Parse(wi.Id)).ToList();
 
-            var workItemsForConsole = string.Join(", ",workItemIds.Select(x => x));
-            Console.WriteLine($"{workItemIds.Count} linked work items found for BuildNumber={build.BuildNumber}, BuildId={build.Id}: {workItemsForConsole}");
+            var workItemsForConsole = string.Join(", ",workItemIds);
+            Console.WriteLine($"{workItemIds.Count} referenced work items found for BuildNumber={build.BuildNumber}, BuildId={build.Id}: {workItemsForConsole}");
 
             return workItemIds;
         }

--- a/src/ServiceNowCLI.Core/AzureDevOps/ChangeRequestLogic.cs
+++ b/src/ServiceNowCLI.Core/AzureDevOps/ChangeRequestLogic.cs
@@ -1,4 +1,5 @@
-﻿using Fluid;
+﻿using CommandLine;
+using Fluid;
 using Microsoft.Azure.Pipelines.WebApi;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
@@ -64,8 +65,17 @@ namespace ServiceNowCLI.Core.AzureDevOps
 
             ValidateBranchUsedForBuild(buildLogic, build, crInputs, isProd, pipeline.Configuration.Type == ConfigurationType.Yaml);
 
-            var buildLinkedWorkItemReferences = buildLogic.GetBuildLinkedWorkItems(build);
-            var workItems = workItemLogic.GetWorkItemsLinkedToBuild(buildLinkedWorkItemReferences, build, arguments);
+            var buildLinkedWorkItemIds = buildLogic.GetBuildLinkedWorkItemIds(build);
+            var addWorkitemsIds = arguments.GetAddWorkitemIds();
+            if (addWorkitemsIds.Count > 0)
+            {
+                Console.WriteLine($"Checking additional {addWorkitemsIds.Count} work items specified in arguments");
+            }
+
+            var addWorkitems = workItemLogic.GetWorkItems(buildLinkedWorkItemIds.Concat(addWorkitemsIds).ToList());
+
+            var workItems = workItemLogic.FilterWorkitemsLinkedToBuild(addWorkitems, build, arguments);
+
             var changeDescriptions = changeDescriptionGenerator.GenerateChangeDescription(workItems);
 
             var changeRequest = CreateChangeRequest(crInputs, arguments, changeDescriptions);

--- a/src/ServiceNowCLI.Core/AzureDevOps/ChangeRequestLogic.cs
+++ b/src/ServiceNowCLI.Core/AzureDevOps/ChangeRequestLogic.cs
@@ -71,9 +71,10 @@ namespace ServiceNowCLI.Core.AzureDevOps
                 Console.WriteLine($"Checking additional {addWorkitemIds.Count} work items specified in arguments");
             }
 
-            var addWorkitems = workItemLogic.GetWorkItems(buildLinkedWorkItemIds.Concat(addWorkitemIds).ToList());
+            var allWorkitemIds = buildLinkedWorkItemIds.Concat(addWorkitemIds).Distinct().ToList();
+            var allWorkitems = workItemLogic.GetWorkItems(allWorkitemIds);
 
-            var workItems = workItemLogic.FilterWorkitemsLinkedToBuild(addWorkitems, build, arguments);
+            var workItems = workItemLogic.FilterWorkitemsLinkedToBuild(allWorkitems, build, arguments);
 
             var changeDescriptions = changeDescriptionGenerator.GenerateChangeDescription(workItems);
 

--- a/src/ServiceNowCLI.Core/AzureDevOps/ChangeRequestLogic.cs
+++ b/src/ServiceNowCLI.Core/AzureDevOps/ChangeRequestLogic.cs
@@ -1,5 +1,4 @@
-﻿using CommandLine;
-using Fluid;
+﻿using Fluid;
 using Microsoft.Azure.Pipelines.WebApi;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
@@ -66,13 +65,13 @@ namespace ServiceNowCLI.Core.AzureDevOps
             ValidateBranchUsedForBuild(buildLogic, build, crInputs, isProd, pipeline.Configuration.Type == ConfigurationType.Yaml);
 
             var buildLinkedWorkItemIds = buildLogic.GetBuildLinkedWorkItemIds(build);
-            var addWorkitemsIds = arguments.GetAddWorkitemIds();
-            if (addWorkitemsIds.Count > 0)
+            var addWorkitemIds = arguments.GetAddWorkitemIds();
+            if (addWorkitemIds.Count > 0)
             {
-                Console.WriteLine($"Checking additional {addWorkitemsIds.Count} work items specified in arguments");
+                Console.WriteLine($"Checking additional {addWorkitemIds.Count} work items specified in arguments");
             }
 
-            var addWorkitems = workItemLogic.GetWorkItems(buildLinkedWorkItemIds.Concat(addWorkitemsIds).ToList());
+            var addWorkitems = workItemLogic.GetWorkItems(buildLinkedWorkItemIds.Concat(addWorkitemIds).ToList());
 
             var workItems = workItemLogic.FilterWorkitemsLinkedToBuild(addWorkitems, build, arguments);
 

--- a/src/ServiceNowCLI.Core/AzureDevOps/WorkItemLogic.cs
+++ b/src/ServiceNowCLI.Core/AzureDevOps/WorkItemLogic.cs
@@ -35,6 +35,11 @@ namespace ServiceNowCLI.Core.AzureDevOps
 
         public List<WorkItem> GetWorkItems(List<int> workItemIds)
         {
+            if (workItemIds == null || workItemIds.Count == 0)
+            {
+                return new List<WorkItem>();
+            }
+
             var workItems = _workItemTrackingHttpClient.GetWorkItemsBatchAsync(new WorkItemBatchGetRequest 
             { 
                 Ids = workItemIds, 
@@ -66,7 +71,7 @@ namespace ServiceNowCLI.Core.AzureDevOps
 
             if (validWorkItems.Count == 0)
                 throw new ArgumentException(
-                    "No Work Items could be found for release, please ensure that your build has linked work items!");
+                    "No Work Items could be found for release. Either your build has no linked work items, or the specified work items did not meet the filtering criteria.");
 
             return validWorkItems;
         }

--- a/src/ServiceNowCLI.Core/AzureDevOps/WorkItemLogic.cs
+++ b/src/ServiceNowCLI.Core/AzureDevOps/WorkItemLogic.cs
@@ -33,20 +33,29 @@ namespace ServiceNowCLI.Core.AzureDevOps
             return await _workItemTrackingHttpClient.GetWorkItemAsync(teamProjectName, workItemId, null, null, WorkItemExpand.All);
         }
 
-        public List<WorkItem> GetWorkItemsLinkedToBuild(List<ResourceRef> workItemReferencesFromBuild, Build build, CreateCrOptions arguments)
+        public List<WorkItem> GetWorkItems(List<int> workItemIds)
+        {
+            var workItems = _workItemTrackingHttpClient.GetWorkItemsBatchAsync(new WorkItemBatchGetRequest 
+            { 
+                Ids = workItemIds, 
+                Expand = WorkItemExpand.All
+            }).GetAwaiter().GetResult();
+
+            return workItems;
+        }
+
+        public List<WorkItem> FilterWorkitemsLinkedToBuild(List<WorkItem> workItems, Build build, CreateCrOptions arguments)
         {
             // If you start with a build and get linked work items, you often get additional work items that are not required
             // This takes the list of linked work items from the build, and then checks the work item to see if it is linked to the build
             // and it will then only return the subset of the work items that are linked to the build.
-            var workItems = new List<WorkItem>();
+            var validWorkItems = new List<WorkItem>();
 
             var buildUri = build.Uri;
 
-            foreach (var workItemReference in workItemReferencesFromBuild)
+            foreach (var workItem in workItems)
             {
-                var workItemId = int.Parse(workItemReference.Id);
-
-                var workItem = GetWorkItemAsync(workItemId).GetAwaiter().GetResult();
+                //var workItem = GetWorkItemAsync(workItemId).GetAwaiter().GetResult();
 
                 if (ShouldWorkItemBeIncluded(workItem, buildUri.ToString(), arguments))
                 {
@@ -54,10 +63,10 @@ namespace ServiceNowCLI.Core.AzureDevOps
                 }
             }
 
-            var workItemsForConsole = string.Join(", ", workItems.Select(x => x.Id));
-            Console.WriteLine($"Found {workItems.Count} work items that are linked to BuildNumber={build.BuildNumber}, BuildId={build.Id}: {workItemsForConsole}");
+            var workItemsForConsole = string.Join(", ", validWorkItems.Select(x => x.Id));
+            Console.WriteLine($"Found {validWorkItems.Count} work items that are linked to BuildNumber={build.BuildNumber}, BuildId={build.Id}: {workItemsForConsole}");
 
-            return workItems;
+            return validWorkItems;
         }
 
         private bool ShouldWorkItemBeIncluded(WorkItem workItem, string buildUri, CreateCrOptions arguments)
@@ -67,7 +76,7 @@ namespace ServiceNowCLI.Core.AzureDevOps
                 return true;
             }
 
-            var workItemRelations = workItem.Relations;
+            var workItemRelations = workItem.Relations ?? new List<WorkItemRelation>();
 
             foreach (var relation in workItemRelations)
             {

--- a/src/ServiceNowCLI.Core/AzureDevOps/WorkItemLogic.cs
+++ b/src/ServiceNowCLI.Core/AzureDevOps/WorkItemLogic.cs
@@ -64,6 +64,10 @@ namespace ServiceNowCLI.Core.AzureDevOps
             var workItemsForConsole = string.Join(", ", validWorkItems.Select(x => x.Id));
             Console.WriteLine($"Found {validWorkItems.Count} work items that are linked to BuildNumber={build.BuildNumber}, BuildId={build.Id}: {workItemsForConsole}");
 
+            if (validWorkItems.Count == 0)
+                throw new ArgumentException(
+                    "No Work Items could be found for release, please ensure that your build has linked work items!");
+
             return validWorkItems;
         }
 

--- a/src/ServiceNowCLI.Core/AzureDevOps/WorkItemLogic.cs
+++ b/src/ServiceNowCLI.Core/AzureDevOps/WorkItemLogic.cs
@@ -55,11 +55,9 @@ namespace ServiceNowCLI.Core.AzureDevOps
 
             foreach (var workItem in workItems)
             {
-                //var workItem = GetWorkItemAsync(workItemId).GetAwaiter().GetResult();
-
                 if (ShouldWorkItemBeIncluded(workItem, buildUri.ToString(), arguments))
                 {
-                    workItems.Add(workItem);
+                    validWorkItems.Add(workItem);
                 }
             }
 


### PR DESCRIPTION
Introduce parameter -a which allows to pass a list of workitem IDs to add to the CR, even if they are in different project than defined in cr-inputs.json